### PR TITLE
fix: add -R flag to less for LESS_TERMCAP color support

### DIFF
--- a/lib/pager.zsh
+++ b/lib/pager.zsh
@@ -84,12 +84,13 @@ zvm_open_less() {
   
   # Always pipe through ZVM_MAN_PAGER to override system MANPAGER
   # This prevents issues when MANPAGER is set to nvim/vim but ZVM_MAN_PAGER is less
+  # Use -R to pass through raw escape sequences (needed for LESS_TERMCAP_* colors)
   if [[ -n "$pattern" ]]; then
-    MANPAGER=cat man "$man_page" 2>/dev/null | ${ZVM_MAN_PAGER} -p "${pattern}" 2>/dev/null || \
-      MANPAGER=cat man "$man_page" 2>/dev/null | ${ZVM_MAN_PAGER} || \
+    MANPAGER=cat man "$man_page" 2>/dev/null | ${ZVM_MAN_PAGER} -R -p "${pattern}" 2>/dev/null || \
+      MANPAGER=cat man "$man_page" 2>/dev/null | ${ZVM_MAN_PAGER} -R || \
       return 1
   else
-    MANPAGER=cat man "$man_page" 2>/dev/null | ${ZVM_MAN_PAGER} || return 1
+    MANPAGER=cat man "$man_page" 2>/dev/null | ${ZVM_MAN_PAGER} -R || return 1
   fi
   
   return 0


### PR DESCRIPTION
## Summary

Fixes #1 

Adds the `-R` flag to all `less` invocations in `zvm_open_less()` to enable raw escape sequence passthrough.

## Problem

Users who rely on `LESS_TERMCAP_*` environment variables for man page colors were not seeing colors when using this plugin. This is because:

1. The plugin sets `MANPAGER=cat` to capture raw man output
2. The output is piped to `less` without the `-R` flag
3. Without `-R`, less doesn't pass through ANSI escape sequences needed for color display

## Solution

Add `-R` flag to all `less` calls, which tells less to interpret raw control characters. This enables:
- `LESS_TERMCAP_*` color variables to work correctly
- ANSI color codes from man pages to display properly

## Changes

- `lib/pager.zsh`: Added `-R` flag to all `${ZVM_MAN_PAGER}` invocations in `zvm_open_less()`