### PR TITLE
Fix less colors

### DIFF
--- a/lib/pager.zsh
+++ b/lib/pager.zsh
@@ -82,14 +82,14 @@ zvm_open_less() {
   local man_page="$1"
   local pattern="$2"
   
-  # Always pipe through ZVM_MAN_PAGER to override system MANPAGER
+  # Always override system MANPAGER
   # This prevents issues when MANPAGER is set to nvim/vim but ZVM_MAN_PAGER is less
   if [[ -n "$pattern" ]]; then
-    MANPAGER=cat man "$man_page" 2>/dev/null | ${ZVM_MAN_PAGER} -p "${pattern}" 2>/dev/null || \
-      MANPAGER=cat man "$man_page" 2>/dev/null | ${ZVM_MAN_PAGER} || \
+    man --pager="${ZVM_MAN_PAGER} -p '${pattern}'" "$man_page" || \
+      man --pager="${ZVM_MAN_PAGER}" "$man_page" || \
       return 1
   else
-    MANPAGER=cat man "$man_page" 2>/dev/null | ${ZVM_MAN_PAGER} || return 1
+    man --pager="${ZVM_MAN_PAGER}" "$man_page" || return 1
   fi
   
   return 0

--- a/lib/pager.zsh
+++ b/lib/pager.zsh
@@ -84,10 +84,8 @@ zvm_open_less() {
   
   # Always override system MANPAGER
   # This prevents issues when MANPAGER is set to nvim/vim but ZVM_MAN_PAGER is less
-  if [[ -n "$pattern" ]]; then
-    man --pager="${ZVM_MAN_PAGER} -p '${pattern}'" "$man_page" || \
-      man --pager="${ZVM_MAN_PAGER}" "$man_page" || \
-      return 1
+  if [[ -n "$pattern" ]] && man --pager=cat "$man_page" | grep -qE "${pattern}"; then
+    man --pager="${ZVM_MAN_PAGER} -p '${pattern}'" "$man_page" || return 1
   else
     man --pager="${ZVM_MAN_PAGER}" "$man_page" || return 1
   fi

--- a/lib/pager.zsh
+++ b/lib/pager.zsh
@@ -84,7 +84,7 @@ zvm_open_less() {
   
   # Always override system MANPAGER
   # This prevents issues when MANPAGER is set to nvim/vim but ZVM_MAN_PAGER is less
-  if [[ -n "$pattern" ]] && man --pager=cat "$man_page" | grep -qE "${pattern}"; then
+  if [[ -n "$pattern" ]] && man --pager=cat "$man_page" 2>/dev/null | grep -qE "${pattern}"; then
     man --pager="${ZVM_MAN_PAGER} -p '${pattern}'" "$man_page" || return 1
   else
     man --pager="${ZVM_MAN_PAGER}" "$man_page" || return 1

--- a/lib/pattern.zsh
+++ b/lib/pattern.zsh
@@ -42,6 +42,10 @@ zvm_build_less_pattern() {
     pattern="^[[:space:]]*${word}([,/=:[[:space:]]|$)|^[[:space:]]*(-[^[:space:],/]*[,/][[:space:]]+)+${word}([,/=:[[:space:]]|$)"
   fi
   
+  # By adding this impossible to match prefix that contains an uppercase character,
+  # we force the search to be case sensitive without affecting the results otherwise
+  pattern="Z^|$pattern"
+
   echo "$pattern"
 }
 

--- a/zsh-vi-man.zsh
+++ b/zsh-vi-man.zsh
@@ -49,8 +49,9 @@ function zvm-man() {
   # Clear screen and open man page with appropriate pager
   zle -I
   
-  if ! zvm_open_man_page "$man_page" "$word"; then
+  if ! man -w "$man_page" &>/dev/null || ! zvm_open_man_page "$man_page" "$word"; then
     zle -M "No manual entry for ${man_page}"
+    return 1
   fi
   
   zle reset-prompt


### PR DESCRIPTION
## Description

- Use the `--pager=` option for `man` in `zvm_open_less` instead of using `MANPAGER=cat` and piping through less
    - this way, stdout of man is a tty (which man checks), enabling the proper man formatting meant for ttys, e.g. color
- In `zvm_open_less`, check whether there is a match for the pattern in the man page and only use the `-p  <pattern>` option for less if it is known a match exists
    - this change prevents just seeing `Pattern not found (press RETURN)`
    - I believe this is the originally intended behavior of the former command *< man | less with pattern >* || *< man | less >* || return 1`
- make pattern matching in less case-sensitive
    - by default, the search in less is case-insensitive if there are only lowercase characters in the search pattern, meaning with the current version of this plugin, pressing the hotkey on `less -r` will match the lines for both `-r` and `-R` in the man page.
    - This can be fixed by adding an impossible to match alternative to the regex, which contains an uppercase character, e.g. `Z^|`
- only try to open the man page if it exists
    - if it does not exist or if `zvm_open_man_page` returns an error status, print an error message and return without resetting the prompt (which would otherwise clear the error message immediately)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Related Issues

Fixes #1 and miscellaneous small problems for which no issue has been created 

## Testing

- [x] Ran `zsh test_patterns.zsh` - all tests pass
- [x] Tested manually

Test environment:

- Zsh version: zsh 5.9 (x86_64-pc-linux-gnu)
- OS: 6.12.73-1-MANJARO x86_64 GNU/Linux

## Checklist

- [x] Code follows project style
- [x] Self-reviewed
- [x] Tests pass
- [ ] Documentation updated (if needed)
